### PR TITLE
chore: SDK 2.8.0 y NFC 2.16.0 en demos (Pods y SPM)

### DIFF
--- a/onboarding-fileuploader.demo/Podfile
+++ b/onboarding-fileuploader.demo/Podfile
@@ -11,14 +11,14 @@ target 'demosdk' do
 
   pod 'IQKeyboardManagerSwift', '~> 7.0.1'
 
-  pod 'FPHISDKVideoRecordingComponent', '~> 2.7.0'
-  pod 'FPHISDKSelphIDMBSDRComponent', '~> 2.7.0'
-  pod 'FPHISDKCaptureComponent', '~> 2.7.0'
-  pod 'FPHISDKMainComponent', '~> 2.7.0'
-  pod 'FPHISDKSelphiComponent', '~> 2.7.0'
-  pod 'FPHISDKStatusComponent', '~> 2.7.0'
-  pod 'FPHISDKTokenizeComponent', '~> 2.7.0'
-  pod 'FPHISDKTrackingComponent', '~> 2.7.0'
+  pod 'FPHISDKVideoRecordingComponent', '~> 2.8.0'
+  pod 'FPHISDKSelphIDMBSDRComponent', '~> 2.8.0'
+  pod 'FPHISDKCaptureComponent', '~> 2.8.0'
+  pod 'FPHISDKMainComponent', '~> 2.8.0'
+  pod 'FPHISDKSelphiComponent', '~> 2.8.0'
+  pod 'FPHISDKStatusComponent', '~> 2.8.0'
+  pod 'FPHISDKTokenizeComponent', '~> 2.8.0'
+  pod 'FPHISDKTrackingComponent', '~> 2.8.0'
 end
 
 post_install do |installer|

--- a/sdkmobile-demo-classic-pods/Podfile
+++ b/sdkmobile-demo-classic-pods/Podfile
@@ -13,12 +13,12 @@ target 'demosdk' do
   use_frameworks!
   
 ##### Remote Dependencies
-  pod 'FPHISDKMainComponent', '~> 2.7.0'
-  pod 'FPHISDKTrackingComponent', '~> 2.7.0'
-  pod 'FPHISDKSelphIDComponent', '~> 2.7.0'
-  pod 'FPHISDKSelphiComponent', '~> 2.7.0'
-  pod 'FPHISDKTokenizeComponent', '~> 2.7.0'
-  pod 'FPHISDKStatusComponent', '~> 2.7.0'
+  pod 'FPHISDKMainComponent', '~> 2.8.0'
+  pod 'FPHISDKTrackingComponent', '~> 2.8.0'
+  pod 'FPHISDKSelphIDComponent', '~> 2.8.0'
+  pod 'FPHISDKSelphiComponent', '~> 2.8.0'
+  pod 'FPHISDKTokenizeComponent', '~> 2.8.0'
+  pod 'FPHISDKStatusComponent', '~> 2.8.0'
 
   target 'demosdkTests' do
     inherit! :search_paths

--- a/sdkmobile-demo-classic-videorcording.pods/Podfile
+++ b/sdkmobile-demo-classic-videorcording.pods/Podfile
@@ -13,13 +13,13 @@ target 'demosdk' do
   use_frameworks!
   
 ##### Remote Dependencies
-  pod 'FPHISDKMainComponent', '~> 2.7.0'
-  pod 'FPHISDKTrackingComponent', '~> 2.7.0'
-  pod 'FPHISDKSelphIDComponent', '~> 2.7.0'
-  pod 'FPHISDKSelphiComponent', '~> 2.7.0'
-  pod 'FPHISDKTokenizeComponent', '~> 2.7.0'
-  pod 'FPHISDKStatusComponent', '~> 2.7.0'
-  pod 'FPHISDKVideoRecordingComponent', '~> 2.7.0'
+  pod 'FPHISDKMainComponent', '~> 2.8.0'
+  pod 'FPHISDKTrackingComponent', '~> 2.8.0'
+  pod 'FPHISDKSelphIDComponent', '~> 2.8.0'
+  pod 'FPHISDKSelphiComponent', '~> 2.8.0'
+  pod 'FPHISDKTokenizeComponent', '~> 2.8.0'
+  pod 'FPHISDKStatusComponent', '~> 2.8.0'
+  pod 'FPHISDKVideoRecordingComponent', '~> 2.8.0'
 
   target 'demosdkTests' do
     inherit! :search_paths

--- a/sdkmobile-demo-full/Podfile
+++ b/sdkmobile-demo-full/Podfile
@@ -9,29 +9,29 @@ target 'demosdk' do
   # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!
 
-  pod 'FPHISDKVideoRecordingComponent', '~> 2.7.0'
-#  pod 'FPHISDKSelphIDComponent', '~> 2.7.0'
-#  pod 'FPHISDKSelphIDLightComponent', '~> 2.7.0'
-#  pod 'FPHISDKSelphIDFullComponent', '~> 2.7.0'
-  pod 'FPHISDKSelphIDMBSDRComponent', '~> 2.7.0'
-#  pod 'FPHISDKSelphIDMLRGLComponent', '~> 2.7.0'
-#  pod 'FPHISDKSelphIDRGLComponent', '~> 2.7.0'
-  pod 'FPHISDKCaptureComponent', '~> 2.7.0'
-  pod 'FPHISDKMainComponent', '~> 2.7.0'
-  pod 'FPHISDKNFCComponent', '~> 2.15.0'
-  pod 'FPHISDKSelphiComponent', '~> 2.7.0'
-  pod 'FPHISDKStatusComponent', '~> 2.7.0'
-  pod 'FPHISDKTokenizeComponent', '~> 2.7.0'
-  pod 'FPHISDKTrackingComponent', '~> 2.7.0'
-  pod 'FPHISDKVideoCallComponent', '~> 2.7.0'
-  pod 'FPHISDKVideoIDComponent', '~> 2.7.0'
-  pod 'FPHISDKVoiceIDComponent', '~> 2.7.0'
-  pod 'FPHISDKPhingersTFComponent', '~> 2.7.0'
+  pod 'FPHISDKVideoRecordingComponent', '~> 2.8.0'
+#  pod 'FPHISDKSelphIDComponent', '~> 2.8.0'
+#  pod 'FPHISDKSelphIDLightComponent', '~> 2.8.0'
+#  pod 'FPHISDKSelphIDFullComponent', '~> 2.8.0'
+  pod 'FPHISDKSelphIDMBSDRComponent', '~> 2.8.0'
+#  pod 'FPHISDKSelphIDMLRGLComponent', '~> 2.8.0'
+#  pod 'FPHISDKSelphIDRGLComponent', '~> 2.8.0'
+  pod 'FPHISDKCaptureComponent', '~> 2.8.0'
+  pod 'FPHISDKMainComponent', '~> 2.8.0'
+  pod 'FPHISDKNFCComponent', '~> 2.16.0'
+  pod 'FPHISDKSelphiComponent', '~> 2.8.0'
+  pod 'FPHISDKStatusComponent', '~> 2.8.0'
+  pod 'FPHISDKTokenizeComponent', '~> 2.8.0'
+  pod 'FPHISDKTrackingComponent', '~> 2.8.0'
+  pod 'FPHISDKVideoCallComponent', '~> 2.8.0'
+  pod 'FPHISDKVideoIDComponent', '~> 2.8.0'
+  pod 'FPHISDKVoiceIDComponent', '~> 2.8.0'
+  pod 'FPHISDKPhingersTFComponent', '~> 2.8.0'
 end
 
 # target 'videoRecording' do
 #   use_frameworks!
-#   pod 'FPHISDKVideoRecordingComponent', '~> 2.7.0'
+#   pod 'FPHISDKVideoRecordingComponent', '~> 2.8.0'
 # end
 
 post_install do |installer|

--- a/sdkmobile-demo-full/demosdk.xcodeproj/project.pbxproj
+++ b/sdkmobile-demo-full/demosdk.xcodeproj/project.pbxproj
@@ -1124,7 +1124,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-PhingersTF_Component-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1C485FBF2ED5B67D008E8488 /* XCRemoteSwiftPackageReference "SDK-VideoRecording-SPM" */ = {
@@ -1132,7 +1132,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-VideoRecording-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1C485FC52ED5B93E008E8488 /* XCRemoteSwiftPackageReference "SDK-VideoCallPackage-SPM" */ = {
@@ -1140,7 +1140,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-VideoCallPackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1C485FC82ED5B988008E8488 /* XCRemoteSwiftPackageReference "SDK-VideoIDPackage-SPM" */ = {
@@ -1148,7 +1148,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-VideoIDPackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1C485FCB2ED5BE08008E8488 /* XCRemoteSwiftPackageReference "SDK-CapturePackage-SPM" */ = {
@@ -1156,7 +1156,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-CapturePackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1C485FD02ED5BF90008E8488 /* XCRemoteSwiftPackageReference "SDK-SdkPackage-SPM" */ = {
@@ -1164,7 +1164,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-SdkPackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1C485FD52ED5CE9C008E8488 /* XCRemoteSwiftPackageReference "SDK-SelphidMBSDRComponent-SPM" */ = {
@@ -1172,7 +1172,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-SelphidMBSDRComponent-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1C485FD82ED5D405008E8488 /* XCRemoteSwiftPackageReference "SDK-NFC_component-SPM" */ = {
@@ -1180,7 +1180,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-NFC_component-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.15.0;
+				minimumVersion = 2.16.0;
 			};
 		};
 		1C485FDD2ED5D46B008E8488 /* XCRemoteSwiftPackageReference "SDK-VoicePackage-SPM" */ = {
@@ -1188,7 +1188,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-VoicePackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1C7BCFCB2F67F7FF00B5C2B3 /* XCRemoteSwiftPackageReference "SDK-VideoRecording-SPM" */ = {
@@ -1196,7 +1196,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-VideoRecording-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1CC09D942ED4661D0096EE68 /* XCRemoteSwiftPackageReference "SDK-StatusPackage-SPM" */ = {
@@ -1204,7 +1204,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-StatusPackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1CC09D972ED466710096EE68 /* XCRemoteSwiftPackageReference "SDK-TrackingPackage-SPM" */ = {
@@ -1212,7 +1212,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-TrackingPackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1CC09D9A2ED4669A0096EE68 /* XCRemoteSwiftPackageReference "SDK-TokenizePackage-SPM" */ = {
@@ -1220,7 +1220,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-TokenizePackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1CC09D9D2ED466CE0096EE68 /* XCRemoteSwiftPackageReference "SDK-Selphi_component-SPM" */ = {
@@ -1228,7 +1228,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-Selphi_component-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1CC96B632F7D12B6005A94E5 /* XCRemoteSwiftPackageReference "SDK-TrackingPackage-SPM" */ = {
@@ -1236,7 +1236,7 @@
 			repositoryURL = "https://github.com/facephi-clienters/SDK-TrackingPackage-SPM";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1CC96B662F7D12FA005A94E5 /* XCRemoteSwiftPackageReference "SDK-VoicePackage-SPM" */ = {
@@ -1244,7 +1244,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-VoicePackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/sdkmobile-demo-full/demosdk/Themes/CustomThemeStatus.swift
+++ b/sdkmobile-demo-full/demosdk/Themes/CustomThemeStatus.swift
@@ -18,7 +18,7 @@ class CustomThemeStatus: ThemeStatusProtocol {
     var colors: [R.Color: UIColor?] = [:]
 //    = [
 //        R.Color.sdkPrimaryColor: UIColor.red,
-//        R.Color.sdkBackgroundColor: .brown,
+//        R.Color.sdkBackgroundPrimaryColor: .brown,
 //        R.Color.sdkNeutralColor: UIColor.cyan,
 //        .sdkAccentColor: .systemPink]
     

--- a/sdkmobile-demo-idv/Podfile
+++ b/sdkmobile-demo-idv/Podfile
@@ -11,14 +11,14 @@ source 'https://cdn.cocoapods.org/'
 fphi_pods = "remote"
 
 def remote_pods
-  pod 'FPHISDKMainComponent', '~> 2.7.0'
-  pod 'FPHISDKSelphIDComponent', '~> 2.7.0'
-  pod 'FPHISDKSelphiComponent', '~> 2.7.0'
-  pod 'FPHISDKStatusComponent', '~> 2.7.0'
-  pod 'FPHISDKTokenizeComponent', '~> 2.7.0'
-  pod 'FPHISDKTrackingComponent', '~> 2.7.0'
-  pod 'FPHISDKVideoRecordingComponent', '~> 2.7.0'
-  pod 'FPHISDKNFCComponent', '~> 2.15.0'
+  pod 'FPHISDKMainComponent', '~> 2.8.0'
+  pod 'FPHISDKSelphIDComponent', '~> 2.8.0'
+  pod 'FPHISDKSelphiComponent', '~> 2.8.0'
+  pod 'FPHISDKStatusComponent', '~> 2.8.0'
+  pod 'FPHISDKTokenizeComponent', '~> 2.8.0'
+  pod 'FPHISDKTrackingComponent', '~> 2.8.0'
+  pod 'FPHISDKVideoRecordingComponent', '~> 2.8.0'
+  pod 'FPHISDKNFCComponent', '~> 2.16.0'
 end
 
 target 'demosdk' do

--- a/sdkmobile-demo-idv/demosdk.xcodeproj/project.pbxproj
+++ b/sdkmobile-demo-idv/demosdk.xcodeproj/project.pbxproj
@@ -866,7 +866,7 @@
 			repositoryURL = "https://github.com/facephi-clienters/SDK-SdkPackage-SPM";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1CC96B6E2F7D1FB3005A94E5 /* XCRemoteSwiftPackageReference "SDK-SelphidMBSDRComponent-SPM" */ = {
@@ -874,7 +874,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-SelphidMBSDRComponent-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1CC96B712F7D2017005A94E5 /* XCRemoteSwiftPackageReference "SDK-Selphi_component-SPM" */ = {
@@ -882,7 +882,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-Selphi_component-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1CC96B742F7D2041005A94E5 /* XCRemoteSwiftPackageReference "SDK-TrackingPackage-SPM" */ = {
@@ -890,7 +890,7 @@
 			repositoryURL = "https://github.com/facephi-clienters/SDK-TrackingPackage-SPM";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1CC96B772F7D20DB005A94E5 /* XCRemoteSwiftPackageReference "SDK-VideoRecording-SPM" */ = {
@@ -898,7 +898,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-VideoRecording-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1CC96B7A2F7D20FE005A94E5 /* XCRemoteSwiftPackageReference "SDK-NFC_component-SPM" */ = {
@@ -906,7 +906,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-NFC_component-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.15.0;
+				minimumVersion = 2.16.0;
 			};
 		};
 		1CC96B7D2F7D212C005A94E5 /* XCRemoteSwiftPackageReference "SDK-TokenizePackage-SPM" */ = {
@@ -914,7 +914,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-TokenizePackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1CC96B802F7D2141005A94E5 /* XCRemoteSwiftPackageReference "SDK-StatusPackage-SPM" */ = {
@@ -922,7 +922,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-StatusPackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/sdkmobile-demo-nfc-pods/Podfile
+++ b/sdkmobile-demo-nfc-pods/Podfile
@@ -10,11 +10,11 @@ target 'demosdk' do
   use_frameworks!
 
   ##### Use with remote Artifactory Pods
-  pod 'FPHISDKMainComponent', '~> 2.7.0'
-  pod 'FPHISDKTrackingComponent', '~> 2.7.0'
-  pod 'FPHISDKNFCComponent', '~> 2.15.0'
-  pod 'FPHISDKStatusComponent', '~> 2.7.0'
-  pod 'FPHISDKTokenizeComponent', '~> 2.7.0'
+  pod 'FPHISDKMainComponent', '~> 2.8.0'
+  pod 'FPHISDKTrackingComponent', '~> 2.8.0'
+  pod 'FPHISDKNFCComponent', '~> 2.16.0'
+  pod 'FPHISDKStatusComponent', '~> 2.8.0'
+  pod 'FPHISDKTokenizeComponent', '~> 2.8.0'
 
   target 'demosdkTests' do
     inherit! :search_paths

--- a/sdkmobile-demo-phingers-pods/Podfile
+++ b/sdkmobile-demo-phingers-pods/Podfile
@@ -13,11 +13,11 @@ target 'demosdk' do
   use_frameworks!
   
 ##### Remote Dependencies
-  pod 'FPHISDKMainComponent', '~> 2.7.0'
-  pod 'FPHISDKTrackingComponent', '~> 2.7.0'
-  pod 'FPHISDKPhingersTFComponent', '~> 2.7.0'
-  pod 'FPHISDKStatusComponent', '~> 2.7.0'
-  pod 'FPHISDKTokenizeComponent', '~> 2.7.0'
+  pod 'FPHISDKMainComponent', '~> 2.8.0'
+  pod 'FPHISDKTrackingComponent', '~> 2.8.0'
+  pod 'FPHISDKPhingersTFComponent', '~> 2.8.0'
+  pod 'FPHISDKStatusComponent', '~> 2.8.0'
+  pod 'FPHISDKTokenizeComponent', '~> 2.8.0'
  
   target 'demosdkTests' do
     inherit! :search_paths

--- a/sdkmobile-demo-selphi-pods/Podfile
+++ b/sdkmobile-demo-selphi-pods/Podfile
@@ -13,11 +13,11 @@ target 'demosdk' do
   use_frameworks!
   
 ##### Remote Dependencies
-  pod 'FPHISDKMainComponent', '~> 2.7.0'
-  pod 'FPHISDKTrackingComponent', '~> 2.7.0'
-  pod 'FPHISDKSelphiComponent', '~> 2.7.0'
-  pod 'FPHISDKStatusComponent', '~> 2.7.0'
-  pod 'FPHISDKTokenizeComponent', '~> 2.7.0'
+  pod 'FPHISDKMainComponent', '~> 2.8.0'
+  pod 'FPHISDKTrackingComponent', '~> 2.8.0'
+  pod 'FPHISDKSelphiComponent', '~> 2.8.0'
+  pod 'FPHISDKStatusComponent', '~> 2.8.0'
+  pod 'FPHISDKTokenizeComponent', '~> 2.8.0'
 
   target 'demosdkTests' do
     inherit! :search_paths

--- a/sdkmobile-demo-signature-pods/Podfile
+++ b/sdkmobile-demo-signature-pods/Podfile
@@ -10,13 +10,13 @@ target 'demosdk' do
   use_frameworks!
   
 ##### Remote Dependencies
-  pod 'FPHISDKTrackingComponent', '~> 2.7.0'
-  pod 'FPHISDKSelphiComponent', '~> 2.7.0'
-  pod 'FPHISDKVideoIDComponent', '~> 2.7.0'
-  pod 'FPHISDKTokenizeComponent', '~> 2.7.0'
-  pod 'FPHISDKStatusComponent', '~> 2.7.0'
-  pod 'FPHISDKMainComponent', '~> 2.7.0'
-  pod 'FPHISDKStatusComponent', '~> 2.7.0'
+  pod 'FPHISDKTrackingComponent', '~> 2.8.0'
+  pod 'FPHISDKSelphiComponent', '~> 2.8.0'
+  pod 'FPHISDKVideoIDComponent', '~> 2.8.0'
+  pod 'FPHISDKTokenizeComponent', '~> 2.8.0'
+  pod 'FPHISDKStatusComponent', '~> 2.8.0'
+  pod 'FPHISDKMainComponent', '~> 2.8.0'
+  pod 'FPHISDKStatusComponent', '~> 2.8.0'
   
 
   target 'demosdkTests' do

--- a/sdkmobile-demo-videocall-pods/Podfile
+++ b/sdkmobile-demo-videocall-pods/Podfile
@@ -13,11 +13,11 @@ target 'demosdk' do
   use_frameworks!
   
 ##### Remote Dependencies
-  pod 'FPHISDKMainComponent', '~> 2.7.0'
-  pod 'FPHISDKTrackingComponent', '~> 2.7.0'
-  pod 'FPHISDKVideoCallComponent', '~> 2.7.0'
-  pod 'FPHISDKTokenizeComponent', '~> 2.7.0'
-  pod 'FPHISDKStatusComponent', '~> 2.7.0'
+  pod 'FPHISDKMainComponent', '~> 2.8.0'
+  pod 'FPHISDKTrackingComponent', '~> 2.8.0'
+  pod 'FPHISDKVideoCallComponent', '~> 2.8.0'
+  pod 'FPHISDKTokenizeComponent', '~> 2.8.0'
+  pod 'FPHISDKStatusComponent', '~> 2.8.0'
   
   target 'demosdkTests' do
     inherit! :search_paths

--- a/sdkmobile-demo-videoid/Podfile
+++ b/sdkmobile-demo-videoid/Podfile
@@ -13,11 +13,11 @@ target 'demosdk' do
   use_frameworks!
   
 ##### Remote Dependencies
-  pod 'FPHISDKMainComponent', '~> 2.7.0'
-  pod 'FPHISDKTrackingComponent', '~> 2.7.0'
-  pod 'FPHISDKVideoIDComponent', '~> 2.7.0'
-  pod 'FPHISDKTokenizeComponent', '~> 2.7.0'
-  pod 'FPHISDKStatusComponent', '~> 2.7.0'
+  pod 'FPHISDKMainComponent', '~> 2.8.0'
+  pod 'FPHISDKTrackingComponent', '~> 2.8.0'
+  pod 'FPHISDKVideoIDComponent', '~> 2.8.0'
+  pod 'FPHISDKTokenizeComponent', '~> 2.8.0'
+  pod 'FPHISDKStatusComponent', '~> 2.8.0'
 
   target 'demosdkTests' do
     inherit! :search_paths

--- a/sdkmobile-demo-videoid/demosdk.xcodeproj/project.pbxproj
+++ b/sdkmobile-demo-videoid/demosdk.xcodeproj/project.pbxproj
@@ -870,7 +870,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-TokenizePackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1C262F522DCA564700072C32 /* XCRemoteSwiftPackageReference "SDK-SdkPackage-SPM" */ = {
@@ -878,7 +878,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-SdkPackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1C262F532DCA568D00072C32 /* XCRemoteSwiftPackageReference "SDK-TrackingPackage-SPM" */ = {
@@ -886,7 +886,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-TrackingPackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1C262F542DCA583800072C32 /* XCRemoteSwiftPackageReference "SDK-VideoIDPackage-SPM" */ = {
@@ -894,7 +894,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-VideoIDPackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 		1C262F572DCA585500072C32 /* XCRemoteSwiftPackageReference "SDK-StatusPackage-SPM" */ = {
@@ -902,7 +902,7 @@
 			repositoryURL = "git@github.com:facephi-clienters/SDK-StatusPackage-SPM.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.7.0;
+				minimumVersion = 2.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/sdkmobile-demo-voiceid-pods/Podfile
+++ b/sdkmobile-demo-voiceid-pods/Podfile
@@ -13,11 +13,11 @@ target 'demosdk' do
   use_frameworks!
   
 ##### Remote Dependencies
-  pod 'FPHISDKTrackingComponent', '~> 2.7.0'
-  pod 'FPHISDKVoiceIDComponent', '~> 2.7.0'
-  pod 'FPHISDKMainComponent', '~> 2.7.0'
-  pod 'FPHISDKTokenizeComponent', '~> 2.7.0'
-  pod 'FPHISDKStatusComponent', '~> 2.7.0'
+  pod 'FPHISDKTrackingComponent', '~> 2.8.0'
+  pod 'FPHISDKVoiceIDComponent', '~> 2.8.0'
+  pod 'FPHISDKMainComponent', '~> 2.8.0'
+  pod 'FPHISDKTokenizeComponent', '~> 2.8.0'
+  pod 'FPHISDKStatusComponent', '~> 2.8.0'
 
   target 'demosdkTests' do
     inherit! :search_paths


### PR DESCRIPTION
Actualiza las restricciones de versión en todas las demos a **2.8.0** para componentes CocoaPods y `minimumVersion` en proyectos SPM, y a **2.16.0** para `FPHISDKNFCComponent` / `SDK-NFC_component-SPM` donde aplica.

Tras merge, ejecutar `pod install` (y `pod repo-art update` si procede) en cada demo con CocoaPods.

Made with [Cursor](https://cursor.com)